### PR TITLE
Validate malformed packets

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -200,15 +200,21 @@ ParseResult parse_message_detailed(
         return result;
     }
 
-    // Validate message type
+    // Validate message type - check for valid range and reserved types
     uint8_t msg_type = static_cast<uint8_t>(result.message.header.type);
+    if (msg_type == 0x00) {
+        // Type 0x00 is UNKNOWN/reserved - reject explicitly
+        result.result = ValidationResult::ERROR_RESERVED_TYPE;
+        result.error_detail = "Message type 0x00 is reserved and not allowed";
+        return result;
+    }
     if (msg_type > 0x07) {
         result.result = ValidationResult::ERROR_UNKNOWN_MESSAGE_TYPE;
         result.error_detail = "Unknown message type: 0x" + to_hex(msg_type);
         return result;
     }
 
-    // Validate payload length field
+    // Validate payload length field - check for zero-length with non-zero actual data
     if (result.message.header.length > config.max_payload_size) {
         result.result = ValidationResult::ERROR_PAYLOAD_TOO_LARGE;
         result.error_detail = "Payload length " + std::to_string(result.message.header.length) +
@@ -217,7 +223,8 @@ ParseResult parse_message_detailed(
         return result;
     }
 
-    // Validate that we have enough data for the claimed payload
+    // Validate that length field is consistent with actual data
+    // Length field claims more payload than we have
     size_t total_expected = sizeof(MessageHeader) + result.message.header.length;
     if (length < total_expected) {
         result.result = ValidationResult::ERROR_TRUNCATED_MESSAGE;
@@ -225,6 +232,37 @@ ParseResult parse_message_detailed(
                              std::to_string(total_expected) + " bytes, got " +
                              std::to_string(length);
         return result;
+    }
+
+    // Check for length field mismatch - actual data exceeds claimed length
+    // This catches malformed packets where length is understated
+    size_t actual_payload = length - sizeof(MessageHeader);
+    if (actual_payload > result.message.header.length) {
+        result.result = ValidationResult::ERROR_LENGTH_MISMATCH;
+        result.error_detail = "Actual payload " + std::to_string(actual_payload) +
+                             " exceeds declared length " +
+                             std::to_string(result.message.header.length);
+        return result;
+    }
+
+    // Validate checksum field - reject packets with suspicious checksum values
+    // All-zero or all-ones checksums often indicate corrupted/uninitialized data
+    if (config.requires_checksum) {
+        uint16_t computed = calculate_crc16(data, sizeof(MessageHeader) - 2);
+        
+        // Check for suspicious checksum values that don't match computed CRC
+        if ((result.message.header.checksum == 0x0000 || 
+            result.message.header.checksum == 0xFFFF) &&
+            computed != result.message.header.checksum) {
+            result.result = ValidationResult::ERROR_INVALID_CHECKSUM_FIELD;
+            result.error_detail = "Suspicious checksum value 0x" +
+                                 to_hex(result.message.header.checksum >> 8) +
+                                 to_hex(result.message.header.checksum & 0xFF) +
+                                 " does not match computed 0x" +
+                                 to_hex(computed >> 8) +
+                                 to_hex(computed & 0xFF);
+            return result;
+        }
     }
 
     // Copy payload if present
@@ -350,6 +388,12 @@ std::string validation_result_to_string(ValidationResult result) {
             return "Checksum mismatch";
         case ValidationResult::ERROR_INVALID_LENGTH_FIELD:
             return "Invalid length field";
+        case ValidationResult::ERROR_LENGTH_MISMATCH:
+            return "Length field mismatch";
+        case ValidationResult::ERROR_RESERVED_TYPE:
+            return "Reserved message type";
+        case ValidationResult::ERROR_INVALID_CHECKSUM_FIELD:
+            return "Invalid checksum field";
         default:
             return "Unknown error";
     }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -71,7 +71,10 @@ enum class ValidationResult {
     ERROR_PAYLOAD_TOO_LARGE,
     ERROR_TRUNCATED_MESSAGE,
     ERROR_CHECKSUM_MISMATCH,
-    ERROR_INVALID_LENGTH_FIELD
+    ERROR_INVALID_LENGTH_FIELD,
+    ERROR_LENGTH_MISMATCH,
+    ERROR_RESERVED_TYPE,
+    ERROR_INVALID_CHECKSUM_FIELD
 };
 
 // Extended parsing result with detailed error information

--- a/tests/test_fuzzer.cpp
+++ b/tests/test_fuzzer.cpp
@@ -840,6 +840,159 @@ TEST(edge_case_null_buffer) {
 }
 
 // ============================================================================
+// Malformed Packet Validation Tests
+// ============================================================================
+
+TEST(malformed_reserved_type_zero) {
+    protocol::ProtocolConfig config;
+    config.magic_byte = 0xAA;
+    config.little_endian = true;
+
+    // Message type 0x00 is reserved
+    std::vector<uint8_t> msg = {
+        0xAA,                    // magic
+        0x00,                    // type = RESERVED (invalid)
+        0x04, 0x00,              // length = 4
+        0x00, 0x00, 0x00, 0x00,  // sequence
+        0x00, 0x00               // checksum
+    };
+
+    auto result = protocol::parse_message_detailed(msg.data(), msg.size(), config);
+    ASSERT_EQ(result.result, protocol::ValidationResult::ERROR_RESERVED_TYPE);
+}
+
+TEST(malformed_length_mismatch) {
+    protocol::ProtocolConfig config;
+    config.magic_byte = 0xAA;
+    config.little_endian = true;
+    config.requires_checksum = false;
+
+    // Length field says 2 bytes, but we have 4 bytes of payload
+    std::vector<uint8_t> msg = {
+        0xAA,                    // magic
+        0x02,                    // type = DATA
+        0x02, 0x00,              // length = 2 (but actual is 4)
+        0x00, 0x00, 0x00, 0x00,  // sequence
+        0x00, 0x00,              // checksum
+        0x01, 0x02, 0x03, 0x04   // 4 bytes payload (exceeds declared length)
+    };
+
+    auto result = protocol::parse_message_detailed(msg.data(), msg.size(), config);
+    ASSERT_EQ(result.result, protocol::ValidationResult::ERROR_LENGTH_MISMATCH);
+}
+
+TEST(malformed_invalid_checksum_field) {
+    protocol::ProtocolConfig config;
+    config.magic_byte = 0xAA;
+    config.little_endian = true;
+    config.requires_checksum = true;
+
+    // Message with 0x0000 checksum - CRC of header won't be 0x0000 for this data
+    // Using payload that produces a non-zero CRC
+    std::vector<uint8_t> msg = {
+        0xAA,                    // magic
+        0x02,                    // type = DATA
+        0x04, 0x00,              // length = 4
+        0x00, 0x00, 0x00, 0x00,  // sequence
+        0x00, 0x00,              // checksum = 0x0000 (suspicious, won't match)
+        0xDE, 0xAD, 0xBE, 0xEF   // payload that produces non-zero CRC
+    };
+
+    auto result = protocol::parse_message_detailed(msg.data(), msg.size(), config);
+    ASSERT_EQ(result.result, protocol::ValidationResult::ERROR_INVALID_CHECKSUM_FIELD);
+}
+
+TEST(malformed_invalid_checksum_field_ffff) {
+    protocol::ProtocolConfig config;
+    config.magic_byte = 0xAA;
+    config.little_endian = true;
+    config.requires_checksum = true;
+
+    // Message with 0xFFFF checksum - CRC of header won't be 0xFFFF for this data
+    std::vector<uint8_t> msg = {
+        0xAA,                    // magic
+        0x02,                    // type = DATA
+        0x04, 0x00,              // length = 4
+        0x00, 0x00, 0x00, 0x00,  // sequence
+        0xFF, 0xFF,              // checksum = 0xFFFF (suspicious, won't match)
+        0xDE, 0xAD, 0xBE, 0xEF   // payload that produces non-FFFF CRC
+    };
+
+    auto result = protocol::parse_message_detailed(msg.data(), msg.size(), config);
+    ASSERT_EQ(result.result, protocol::ValidationResult::ERROR_INVALID_CHECKSUM_FIELD);
+}
+
+TEST(malformed_unknown_type_high) {
+    protocol::ProtocolConfig config;
+    config.magic_byte = 0xAA;
+    config.little_endian = true;
+
+    // Message type 0xFF is unknown
+    std::vector<uint8_t> msg = {
+        0xAA,                    // magic
+        0xFF,                    // type = UNKNOWN (invalid)
+        0x04, 0x00,              // length = 4
+        0x00, 0x00, 0x00, 0x00,  // sequence
+        0x00, 0x00               // checksum
+    };
+
+    auto result = protocol::parse_message_detailed(msg.data(), msg.size(), config);
+    ASSERT_EQ(result.result, protocol::ValidationResult::ERROR_UNKNOWN_MESSAGE_TYPE);
+}
+
+TEST(malformed_validation_result_strings) {
+    // Test new validation result string conversions
+    ASSERT_EQ(protocol::validation_result_to_string(
+        protocol::ValidationResult::ERROR_LENGTH_MISMATCH), "Length field mismatch");
+    ASSERT_EQ(protocol::validation_result_to_string(
+        protocol::ValidationResult::ERROR_RESERVED_TYPE), "Reserved message type");
+    ASSERT_EQ(protocol::validation_result_to_string(
+        protocol::ValidationResult::ERROR_INVALID_CHECKSUM_FIELD), "Invalid checksum field");
+}
+
+TEST(malformed_exact_length_match) {
+    protocol::ProtocolConfig config;
+    config.magic_byte = 0xAA;
+    config.little_endian = true;
+    config.requires_checksum = false;
+
+    // Valid message where actual payload exactly matches declared length
+    std::vector<uint8_t> msg = {
+        0xAA,                    // magic
+        0x02,                    // type = DATA
+        0x02, 0x00,              // length = 2
+        0x00, 0x00, 0x00, 0x00,  // sequence
+        0x00, 0x00,              // checksum
+        0x01, 0x02               // exactly 2 bytes payload
+    };
+
+    auto result = protocol::parse_message_detailed(msg.data(), msg.size(), config);
+    ASSERT_EQ(result.result, protocol::ValidationResult::OK);
+    ASSERT_TRUE(result.message.valid);
+}
+
+TEST(malformed_trailing_garbage) {
+    protocol::ProtocolConfig config;
+    config.magic_byte = 0xAA;
+    config.little_endian = true;
+    config.requires_checksum = false;
+
+    // Message with extra trailing bytes (garbage after payload)
+    std::vector<uint8_t> msg = {
+        0xAA,                    // magic
+        0x02,                    // type = DATA
+        0x02, 0x00,              // length = 2
+        0x00, 0x00, 0x00, 0x00,  // sequence
+        0x00, 0x00,              // checksum
+        0x01, 0x02,              // 2 bytes payload
+        0xDE, 0xAD, 0xBE, 0xEF   // trailing garbage
+    };
+
+    auto result = protocol::parse_message_detailed(msg.data(), msg.size(), config);
+    ASSERT_EQ(result.result, protocol::ValidationResult::ERROR_LENGTH_MISMATCH);
+}
+
+// ============================================================================
 // Main
 // ============================================================================
 
@@ -900,6 +1053,17 @@ int main() {
     RUN_TEST(edge_case_max_payload);
     RUN_TEST(edge_case_zero_sequence);
     RUN_TEST(edge_case_null_buffer);
+
+    // Malformed packet validation tests
+    std::cout << "\n--- Malformed Packet Validation Tests ---\n";
+    RUN_TEST(malformed_reserved_type_zero);
+    RUN_TEST(malformed_length_mismatch);
+    RUN_TEST(malformed_invalid_checksum_field);
+    RUN_TEST(malformed_invalid_checksum_field_ffff);
+    RUN_TEST(malformed_unknown_type_high);
+    RUN_TEST(malformed_validation_result_strings);
+    RUN_TEST(malformed_exact_length_match);
+    RUN_TEST(malformed_trailing_garbage);
 
     // Summary
     std::cout << "\n=== Test Summary ===\n";


### PR DESCRIPTION
Added stricter validation in `parse_message_detailed` to catch malformed packets that slip through basic checks. Now explicitly rejects reserved message type 0x00, detects length field mismatches where actual payload exceeds the declared size, and flags suspicious checksum values (all-zero or all-ones) that indicate corrupted or uninitialized data. These checks close gaps in the fuzzing surface where edge-case packets could bypass validation.
closes #3